### PR TITLE
CI: fix ModuleNotFoundError: No module named 'packaging'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+python3-packaging
 up42-py


### PR DESCRIPTION
Hopefully fixes CI workflow:

```bash
  > [ 8/14] RUN grass --tmp-location XY --exec g.extension extension=i.up42.import url=. prefix=build --verbose:
2.742   File "/tmp/grass8-root-1/tmpp7vwehyj/i.up42.import/scripts/i.up42.import", line 148, in <module>
2.742     import up42
2.742   File "/src/addon-env/lib/python3.12/site-packages/up42/__init__.py", line 32, in <module>
2.742     from up42.version import version_control
2.742   File "/src/addon-env/lib/python3.12/site-packages/up42/version/version_control.py", line 6, in <module>
2.742     from packaging import version
2.742 ModuleNotFoundError: No module named 'packaging'
2.775 make: *** [/usr/local/grass/include/Make/Html.make:14: i.up42.import.tmp.html] Error 1
2.775 rm i.up42.import.tmp.html
2.776 ERROR: Compilation failed, sorry. Please check above error messages.
```

See [log](https://github.com/mundialis/i.up42.import/actions/runs/19868147859/job/56936375669#step:3:267)